### PR TITLE
Dimension of dense layers

### DIFF
--- a/model/model.py
+++ b/model/model.py
@@ -17,13 +17,14 @@ class RNNModel(nn.Module):
         self.encoder = nn.Embedding(ntoken, int(ninp/2))
         assert rnn_type in ['LSTM'], 'RNN type is not supported'
         if rnn_type == 'LSTM':
+            # in the paper: ninp = nhid (but I think nhid can be any other value as well)
             self.rnns = [torch.nn.LSTM(ninp, nhid, 1, dropout=0) for l in range(nlayers)]
 
         #print(self.rnns)
         self.rnns = torch.nn.ModuleList(self.rnns)
-        self.decoder = nn.Linear(nhid, ntoken)
+        self.decoder = nn.Linear(int(ninp/2), ntoken)
 
-        self.combiner = nn.Linear(ninp, int(ninp/2))
+        self.combiner = nn.Linear(nhid, int(ninp/2))
 
         # Optionally tie weights as in:
         # "Using the Output Embedding to Improve Language Models" (Press & Wolf 2016)


### PR DESCRIPTION
Hi, just want to clarify, 
1) In the paper you used ninp=nhid, but nhid can be set to any other value for the hidden size of LSTM right?
2) The combiner first reduces the dimension of the output vectors (from last layer of LSTM) from nhid to ninp/2, then goes through another dense layer to map it to distribution over vocab right?